### PR TITLE
update version to something valid

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-hdp",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1",
   "author": "jpc",
   "summary": "Configures Historical Data Platform",
   "license": "Apache-2.0",


### PR DESCRIPTION
`bolt module install` cannot parse the version because it assumes semantic versions.  

Update to a semantic version so we can use `bolt module install`