### PR TITLE
Minio fixes

### DIFF
--- a/templates/docker-compose.yaml.epp
+++ b/templates/docker-compose.yaml.epp
@@ -161,7 +161,8 @@ services:
     volumes:
       - "minio-data:/data"
       - "minio-config:/.minio"
-    command: "server /data"
+    entrypoint: "sh"
+    command: -c "mkdir -p /data/facts && mkdir -p /data/reports && mkdir -p /data/spare && /usr/bin/minio server /data"
 <%- } %>
   redis:
     image: "<%= $redis_image %>"

--- a/templates/docker-compose.yaml.epp
+++ b/templates/docker-compose.yaml.epp
@@ -159,7 +159,7 @@ services:
       - "MINIO_ACCESS_KEY=<%= $hdp_s3_access_key %>"
       - "MINIO_SECRET_KEY=<%= unwrap($hdp_s3_secret_key) %>"
     volumes:
-      - "minio-facts:/data/facts"
+      - "minio-data:/data"
       - "minio-config:/.minio"
     command: "server /data"
 <%- } %>
@@ -204,5 +204,5 @@ volumes:
   redis:
   elastic:
   minio-config:
-  minio-facts:
+  minio-data:
 


### PR DESCRIPTION
Minio does not like having different docker volumes mounted in its data dir, so it can keep cp's fast.

We also create the buckets before we start the service.