### PR TITLE
Escape password hashes

### DIFF
--- a/spec/classes/app_stack_spec.rb
+++ b/spec/classes/app_stack_spec.rb
@@ -442,6 +442,29 @@ describe 'hdp::app_stack' do
               .without_content(%r{REACT_APP_SSO_CLIENT_ID=})
           }
         end
+
+        context 'basic - specified hash' do
+          let(:params) do
+            {
+              'dns_name' => 'hdp.test.com',
+              'hdp_query_auth' => 'basic_auth',
+              'hdp_query_username' => 'super-user',
+              'hdp_query_password' => sensitive('$6$foo$bar'),
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it {
+            is_expected.to contain_file('/opt/puppetlabs/hdp/docker-compose.yaml')
+              .with_content(%r{- "HDP_HTTP_QUERY_USER=super-user"})
+              .with_content(%r{- "HDP_HTTP_QUERY_PASSWORD=\$\$6\$\$foo\$\$bar"})
+              .without_content(%r{HDP_HTTP_QUERY_SSO_ISSUER=})
+              .without_content(%r{HDP_HTTP_QUERY_SSO_CLIENTID=})
+              .without_content(%r{HDP_HTTP_QUERY_SSO_AUDIENCE=})
+              .without_content(%r{REACT_APP_SSO_ISSUER=})
+              .without_content(%r{REACT_APP_SSO_CLIENT_ID=})
+          }
+        end
         context 'basic - old behavior' do
           let(:params) do
             {

--- a/templates/docker-compose.yaml.epp
+++ b/templates/docker-compose.yaml.epp
@@ -112,7 +112,7 @@ services:
       - "HDP_HTTP_QUERY_USER=<%= $hdp_query_username %>"
       <%- } %>
       <%- if $hdp_query_password { %>
-      - "HDP_HTTP_QUERY_PASSWORD=<%= unwrap($hdp_query_password) %>"
+      - "HDP_HTTP_QUERY_PASSWORD=<%= regsubst(unwrap($hdp_query_password), '\$', '$$', 'G') %>"
       <%- } %>
     <%- } %>
     <%- if $hdp_query_auth == 'oidc' { %>  


### PR DESCRIPTION
Docker attempts to perform env sub on password hashes, since they must contain a few $.

A user can do this themselves, but it is error prone, and can cause confusing issues.